### PR TITLE
Add Meta Pixel integration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,24 @@
     
     <!-- Canonical URL -->
     <link rel="canonical" href="https://www.samstorybook.com/" />
+    
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1548782352881940');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1548782352881940&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/App.js
+++ b/src/App.js
@@ -74,6 +74,15 @@ function App() {
   useEffect(() => {
     const url = new URL(window.location.href);
     if (url.searchParams.has('submission-success')) {
+      // Fire Meta Pixel Lead event (form/email signup submitted)
+      if (typeof window.fbq === 'function') {
+        window.fbq('track', 'Lead');
+      }
+      // Fire Meta Pixel Purchase event (order completed)
+      if (typeof window.fbq === 'function') {
+        const value = parseFloat(url.searchParams.get('value') || url.searchParams.get('amount') || url.searchParams.get('order_value')) || 38;
+        window.fbq('track', 'Purchase', { value, currency: 'USD' });
+      }
       // Scroll to the form section to show the success message
       setTimeout(() => {
         const formSection = document.querySelector('#form-section');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Integrates Meta Pixel (ID: 1548782352881940) into the React app for conversion tracking.

## Changes

### 1. Base Meta Pixel in index.html
- Added the standard Meta Pixel base code to the `<head>` in `public/index.html`
- PageView fires automatically on every page load
- Includes noscript fallback for users without JavaScript

### 2. Lead event on form submission
- Fires `fbq('track', 'Lead')` when the Fillout form is successfully submitted
- Triggered when the URL contains `submission-success` (Fillout redirect param)

### 3. Purchase event on order success
- Fires `fbq('track', 'Purchase', { value: AMOUNT, currency: 'USD' })` on the order success/thank-you page
- Uses real value: reads from URL params (`value`, `amount`, or `order_value`) if Fillout passes them, otherwise defaults to $38 (product price from ProductInfo)

## Implementation notes
- Uses standard Meta Pixel base code (no third-party React library)
- Both Lead and Purchase fire when `submission-success` is in the URL, since the Fillout form handles the full order flow
- Safe guards: checks `typeof window.fbq === 'function'` before firing events
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7567e6f1-61cc-4228-8934-2727c63040ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7567e6f1-61cc-4228-8934-2727c63040ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

